### PR TITLE
- Gave connoisseur role access to:

### DIFF
--- a/ptn/boozebot/commands/DatabaseInteraction.py
+++ b/ptn/boozebot/commands/DatabaseInteraction.py
@@ -1256,12 +1256,13 @@ class DatabaseInteraction(Cog):
     @cog_ext.cog_slash(
         name="booze_tally_extra_stats",
         guild_ids=[bot_guild_id()],
-        description="Returns an set of extra stats for the wine. Restricted to Admin and Sommelier's.",
+        description="Returns an set of extra stats for the wine. Restricted to Admin, Sommeliers, and Connoisseurs.",
         permissions={
             bot_guild_id(): [
                 create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(server_sommelier_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(server_mod_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_connoisseur_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(bot_guild_id(), SlashCommandPermissionType.ROLE, False),
             ]
         }

--- a/ptn/boozebot/commands/Helper.py
+++ b/ptn/boozebot/commands/Helper.py
@@ -162,7 +162,7 @@ class Helper(commands.Cog):
         elif command == 'booze_tally_extra_stats':
             params = None
             method_desc = 'Logs some stats regarding what the volume of wine looks like.'
-            roles = ['Admin', 'Mod', 'Sommelier']
+            roles = ['Admin', 'Mod', 'Sommelier', 'Connoisseur']
         elif command == 'find_carriers_with_wine':
             params = None
             method_desc = 'Returns all the remaining carriers with wine to unload.'
@@ -288,7 +288,7 @@ class Helper(commands.Cog):
                 }
             ]
             method_desc = 'Toggles a user\'s wine carrier status.'
-            roles = ['Admin', 'Sommelier', 'Mod']
+            roles = ['Admin', 'Sommelier', 'Connoisseur', 'Mod']
         elif command == 'steve_says':
             params = [
                 {

--- a/ptn/boozebot/commands/Unloading.py
+++ b/ptn/boozebot/commands/Unloading.py
@@ -379,7 +379,7 @@ class Unloading(commands.Cog):
     @cog_ext.cog_slash(
         name='Make_Wine_Carrier',
         guild_ids=[bot_guild_id()],
-        description='Toggle user\'s Wine Carrier role. Admin/Sommelier role required.',
+        description='Toggle user\'s Wine Carrier role. Admin/Sommelier/Connoisseur role required.',
         options=[
             create_option(
                 name='user',
@@ -394,11 +394,12 @@ class Unloading(commands.Cog):
                     create_choice(
                         name="Carrier",
                         value="Wine Carrier"
-                    ),
-                    create_choice(
-                        name="Tanker",
-                        value="Wine Tanker"
                     )
+                    #Disabling Tankers as we don't use these anymore
+                    #create_choice(
+                    #    name="Tanker",
+                    #    value="Wine Tanker"
+                    #)
                 ],
                 option_type=3,  # String - look into using 8 'Role' see how we can cache that here
                 required=True
@@ -409,6 +410,7 @@ class Unloading(commands.Cog):
                 create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(server_sommelier_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(server_mod_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_connoisseur_role_id(), SlashCommandPermissionType.ROLE, True),
                 create_permission(bot_guild_id(), SlashCommandPermissionType.ROLE, False),
             ]
         },
@@ -420,8 +422,9 @@ class Unloading(commands.Cog):
         # TODO: Enumerate this
         if set_role == 'Wine Carrier':
             role_id = server_wine_carrier_role_id()
-        elif set_role == 'Wine Tanker':
-            role_id = server_wine_tanker_role_id()
+        #Removing Wine Tankers as we don't use them anymore
+        #elif set_role == 'Wine Tanker':
+        #    role_id = server_wine_tanker_role_id()
         else:
             print(f'Unknown role: {set_role}')
             return await ctx.send(f'Unable to process the role" {set_role}. Report this problem.')


### PR DESCRIPTION
Fixes #355 

- Adds these for Connoisseurs:
make_wine_carrier
booze_tally_extra_stats

- Updated helper message to include connoisseurs

- Also commented out wine tanker for make_wine_carrier as we don't use tankers currently while I was in there