### PR TITLE
Add commands to open/close public channels

### DIFF
--- a/ptn/boozebot/booze.py
+++ b/ptn/boozebot/booze.py
@@ -3,6 +3,7 @@ from ptn.boozebot.commands.DiscordBotCommands import DiscordBotCommands
 from ptn.boozebot.commands.Helper import Helper
 from ptn.boozebot.commands.PublicHoliday import PublicHoliday
 from ptn.boozebot.commands.Unloading import Unloading
+from ptn.boozebot.commands.Cleaner import Cleaner
 from ptn.boozebot.constants import bot, TOKEN, _production
 from ptn.boozebot.database.database import build_database_on_startup
 
@@ -24,6 +25,7 @@ def run():
     bot.add_cog(Helper())
     bot.add_cog(PublicHoliday())
     bot.add_cog(MimicSteve())
+    bot.add_cog(Cleaner())
     bot.run(TOKEN)
 
 

--- a/ptn/boozebot/commands/Cleaner.py
+++ b/ptn/boozebot/commands/Cleaner.py
@@ -38,22 +38,28 @@ class Cleaner(commands.Cog):
         Command to open public channels. Generates a message in the channel that it ran in.
 
         :param SlashContext ctx: The discord slash context.
-        :returns: A discord embed with some emoji's
+        :returns: A discord embed
         """
         print(f'User {ctx.author} requested BC channel opening in channel: {ctx.channel}.')
 
         ids_list = get_public_channel_list()
-        opened_channel_link_list = ["<#" + str(item) + ">" for item in ids_list]
+        guild = bot.get_guild(bot_guild_id())
 
-        embed = discord.Embed(title='Avast! We\'re ready to set sail!')
-        for item in opened_channel_link_list:
-            embed.add_field(name="Opened", value=item, inline=False)
+        embed = discord.Embed()
 
-        await ctx.send(embed=embed)
+        for id in ids_list:
+            channel = bot.get_channel(id)
+            try:
+                await channel.set_permissions(guild.default_role, view_channel=None) # less confusing alias for read_messages
+                embed.add_field(name="Opened", value="<#" + str(id) +">", inline=False)
+            except Exception as e:
+                embed.add_field(name="FAILED to open", value="<#" + str(id) + f">: {e}", inline=False)
+
+        await ctx.send(f"<@&{server_sommelier_role_id()}> Avast! We\'re ready to set sail!", embed=embed)
 
 
     @cog_ext.cog_slash(
-        name="Booze_Channels_Closen",
+        name="Booze_Channels_Close",
         guild_ids=[bot_guild_id()],
         description="Opens the Booze Cruise channels to the public.",
         permissions={
@@ -67,18 +73,24 @@ class Cleaner(commands.Cog):
     )
     async def booze_channels_close(self, ctx: SlashContext):
         """
-        Command to open public channels. Generates a message in the channel that it ran in.
+        Command to close public channels. Generates a message in the channel that it ran in.
 
         :param SlashContext ctx: The discord slash context.
-        :returns: A discord embed with some emoji's
+        :returns: A discord embed
         """
-        print(f'User {ctx.author} requested BC channel opening in channel: {ctx.channel}.')
+        print(f'User {ctx.author} requested BC channel closing in channel: {ctx.channel}.')
 
         ids_list = get_public_channel_list()
-        opened_channel_link_list = ["<#" + str(item) + ">" for item in ids_list]
+        guild = bot.get_guild(bot_guild_id())
 
-        embed = discord.Embed(title='That\'s the end of that, me hearties!')
-        for item in opened_channel_link_list:
-            embed.add_field(name="Closed", value=item, inline=False)
+        embed = discord.Embed()
 
-        await ctx.send(embed=embed)
+        for id in ids_list:
+            channel = bot.get_channel(id)
+            try:
+                await channel.set_permissions(guild.default_role, view_channel=False) # less confusing alias for read_messages
+                embed.add_field(name="Closed", value="<#" + str(id) +">", inline=False)
+            except Exception as e:
+                embed.add_field(name="FAILED to close", value="<#" + str(id) + f">: {e}", inline=False)
+
+        await ctx.send(f"<@&{server_sommelier_role_id()}> That\'s the end of that, me hearties.", embed=embed)

--- a/ptn/boozebot/commands/Cleaner.py
+++ b/ptn/boozebot/commands/Cleaner.py
@@ -1,0 +1,84 @@
+import discord
+from discord.ext import commands
+from discord_slash import SlashContext, cog_ext
+from discord_slash.utils.manage_commands import create_option, create_choice
+from discord_slash.utils.manage_commands import create_permission
+from discord_slash.model import SlashCommandPermissionType
+
+from ptn.boozebot.BoozeCarrier import BoozeCarrier
+from ptn.boozebot.constants import bot_guild_id, get_custom_assassin_id, bot, get_discord_booze_unload_channel, \
+    server_admin_role_id, server_sommelier_role_id, server_connoisseur_role_id, server_wine_carrier_role_id, \
+    server_mod_role_id, get_primary_booze_discussions_channel, get_fc_complete_id, server_wine_tanker_role_id, \
+    get_wine_tanker_role, get_discord_tanker_unload_channel, \
+    get_public_channel_list
+from ptn.boozebot.database.database import pirate_steve_db, pirate_steve_lock, pirate_steve_conn
+
+
+class Cleaner(commands.Cog):
+    def __init__(self):
+        """
+        This class handles role and channel cleanup after a cruise, as well as opening channels in preparation for a cruise.
+        """
+
+    @cog_ext.cog_slash(
+        name="Booze_Channels_Open",
+        guild_ids=[bot_guild_id()],
+        description="Opens the Booze Cruise channels to the public.",
+        permissions={
+            bot_guild_id(): [
+                create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_sommelier_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_mod_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(bot_guild_id(), SlashCommandPermissionType.ROLE, False),
+            ]
+        },
+    )
+    async def booze_channels_open(self, ctx: SlashContext):
+        """
+        Command to open public channels. Generates a message in the channel that it ran in.
+
+        :param SlashContext ctx: The discord slash context.
+        :returns: A discord embed with some emoji's
+        """
+        print(f'User {ctx.author} requested BC channel opening in channel: {ctx.channel}.')
+
+        ids_list = get_public_channel_list()
+        opened_channel_link_list = ["<#" + str(item) + ">" for item in ids_list]
+
+        embed = discord.Embed(title='Avast! We\'re ready to set sail!')
+        for item in opened_channel_link_list:
+            embed.add_field(name="Opened", value=item, inline=False)
+
+        await ctx.send(embed=embed)
+
+
+    @cog_ext.cog_slash(
+        name="Booze_Channels_Closen",
+        guild_ids=[bot_guild_id()],
+        description="Opens the Booze Cruise channels to the public.",
+        permissions={
+            bot_guild_id(): [
+                create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_sommelier_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(server_mod_role_id(), SlashCommandPermissionType.ROLE, True),
+                create_permission(bot_guild_id(), SlashCommandPermissionType.ROLE, False),
+            ]
+        },
+    )
+    async def booze_channels_close(self, ctx: SlashContext):
+        """
+        Command to open public channels. Generates a message in the channel that it ran in.
+
+        :param SlashContext ctx: The discord slash context.
+        :returns: A discord embed with some emoji's
+        """
+        print(f'User {ctx.author} requested BC channel opening in channel: {ctx.channel}.')
+
+        ids_list = get_public_channel_list()
+        opened_channel_link_list = ["<#" + str(item) + ">" for item in ids_list]
+
+        embed = discord.Embed(title='That\'s the end of that, me hearties!')
+        for item in opened_channel_link_list:
+            embed.add_field(name="Closed", value=item, inline=False)
+
+        await ctx.send(embed=embed)

--- a/ptn/boozebot/commands/DatabaseInteraction.py
+++ b/ptn/boozebot/commands/DatabaseInteraction.py
@@ -78,7 +78,7 @@ class DatabaseInteraction(Cog):
     @cog_ext.cog_slash(
         name="update_booze_db",
         guild_ids=[bot_guild_id()],
-        description="Populates the booze cruise database from the updated google sheet. Admin/Sommelier/Connoisseur role required.",
+        description="Populates the booze cruise database from the updated google sheet. Somm/Conn role required.",
         permissions={
             bot_guild_id(): [
                 create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),
@@ -873,7 +873,7 @@ class DatabaseInteraction(Cog):
     @cog_ext.cog_slash(
         name="booze_tally",
         guild_ids=[bot_guild_id()],
-        description="Returns a summary of the stats for the current booze cruise. Restricted to Admin, Sommeliers, and Connoisseurs.",
+        description="Returns a summary of the stats for the current booze cruise. Restricted to Somms and Connoisseurs.",
         permissions={
             bot_guild_id(): [
                 create_permission(server_admin_role_id(), SlashCommandPermissionType.ROLE, True),

--- a/ptn/boozebot/commands/Unloading.py
+++ b/ptn/boozebot/commands/Unloading.py
@@ -9,7 +9,7 @@ from discord_slash.model import SlashCommandPermissionType
 
 from ptn.boozebot.BoozeCarrier import BoozeCarrier
 from ptn.boozebot.constants import bot_guild_id, get_custom_assassin_id, bot, get_discord_booze_unload_channel, \
-    server_admin_role_id, server_sommelier_role_id, server_wine_carrier_role_id, \
+    server_admin_role_id, server_sommelier_role_id, server_connoisseur_role_id, server_wine_carrier_role_id, \
     server_mod_role_id, get_primary_booze_discussions_channel, get_fc_complete_id, server_wine_tanker_role_id, \
     get_wine_tanker_role, get_discord_tanker_unload_channel
 from ptn.boozebot.database.database import pirate_steve_db, pirate_steve_lock, pirate_steve_conn
@@ -306,7 +306,7 @@ class Unloading(commands.Cog):
     @cog_ext.cog_slash(
         name='Wine_Unload_Complete',
         guild_ids=[bot_guild_id()],
-        description='Removes any trade channel notification for unloading wine. Admin/Sommelier/Connoisseur/Wine Carrier role required.',
+        description='Removes any trade channel notification for unloading wine. Somm/Conn/Wine Carrier role required.',
         options=[
             create_option(
                 name='carrier_id',

--- a/ptn/boozebot/constants.py
+++ b/ptn/boozebot/constants.py
@@ -29,6 +29,8 @@ PROD_BOOZE_CRUISE_CHAT_CHANNEL = 819295547289501736     # Booze-Cruise
 PROD_FC_COMPLETE_ID = 878216234653605968
 PROD_WINE_TANKER_ID = 978321720630980658
 PROD_TANKER_UNLOAD_CHANNEL_ID = 987972565735727124
+PROD_BC_PUBLIC_CHANNEL_IDS = [838699587249242162, 849460909273120856, 932918003639648306, 819295547289501736, 837764138692378634, 849249916676603944, 1078840174227763301, 1079384804098854972]
+# booze-cruise-announcements, booze-cruise-departures, wine-cellar-unloading, booze-cruise-chat, wine-cellar-deliveries, wine-cellar-loading, booze-snooze-and-garage, Rackham’s Peak Tavern
 
 # Testing variables
 TEST_DISCORD_GUILD = 818174236480897055  # test Discord server
@@ -49,6 +51,8 @@ TEST_BOOZE_CRUISE_CHAT_CHANNEL = 818174236480897058         # General
 TEST_FC_COMPLETE_ID = 884673510067286076
 TEST_WINE_TANKER_ID = 990601307771506708
 TEST_TANKER_UNLOAD_CHANNEL_ID = 995714783678570566
+TEST_BC_PUBLIC_CHANNEL_IDS = [1107757218318782586, 1107757285817712721, 1107757340381425768, 1107757384069288056, 1107757418517110955, 1107757456517505055, 1107757490940153956, 1107757548779601940]
+# booze-cruise-announcements, booze-cruise-departures, wine-cellar-unloading, booze-cruise-chat, wine-cellar-deliveries, wine-cellar-loading, booze-snooze-and-garage, Rackham’s Peak Tavern
 
 BOOZE_PROFIT_PER_TONNE_WINE = 278000
 RACKHAMS_PEAK_POP = 150000
@@ -261,3 +265,12 @@ def get_discord_tanker_unload_channel():
     :rtype: int
     """
     return PROD_TANKER_UNLOAD_CHANNEL_ID if _production else TEST_TANKER_UNLOAD_CHANNEL_ID
+
+def get_public_channel_list():
+    """
+    Gets the list of public BC channels
+
+    :return: The channel IDs
+    :rtype: list, int
+    """
+    return PROD_BC_PUBLIC_CHANNEL_IDS if _production else TEST_BC_PUBLIC_CHANNEL_IDS


### PR DESCRIPTION
Fixes #348
Fixes #362

- new cog: Cleaner.py
- new commands: `booze_channel_open` and `booze_channel_close`
- new constants: channel IDs to be opened/closed