### PR TITLE
fix: always raise EDSM PH check error

### DIFF
--- a/ptn/boozebot/botcommands/PublicHoliday.py
+++ b/ptn/boozebot/botcommands/PublicHoliday.py
@@ -34,9 +34,9 @@ from ptn.boozebot.constants import (
     holiday_query_started_gifs,
     holiday_start_gif,
 )
+from ptn.boozebot.modules.boozeSheetsApi import booze_sheets_api
 from ptn.boozebot.modules.helpers import check_command_channel, check_roles, track_last_run
 from ptn.boozebot.modules.PHcheck import api_ph_check, ph_check
-from ptn.boozebot.modules.boozeSheetsApi import booze_sheets_api
 
 """
 PUBLIC HOLIDAY TASK LOOP
@@ -75,7 +75,9 @@ class PublicHoliday(commands.Cog):
             logger.debug("Public holiday state checker loop already running.")
 
     @staticmethod
-    async def _set_public_holiday_state(state: bool, timestamp: datetime, force_update: bool = False) -> tuple[bool, str]:
+    async def _set_public_holiday_state(
+        state: bool, timestamp: datetime, force_update: bool = False
+    ) -> tuple[bool, str]:
         logger.info(f"Setting public holiday state to: {state}, force update: {force_update}")
         if state:
             logger.info("PH detected, triggering the notifications.")
@@ -160,8 +162,7 @@ class PublicHoliday(commands.Cog):
         try:
             state, updated_at = await api_ph_check()
             logger.info(f"Rackham's holiday API check returned: {state}, last updated: {updated_at}")
-            await self._set_public_holiday_state(state,updated_at)
-
+            await self._set_public_holiday_state(state, updated_at)
         except Exception as e:
             logger.exception(f"Error in the public holiday loop: {e}")
 

--- a/ptn/boozebot/modules/PHcheck.py
+++ b/ptn/boozebot/modules/PHcheck.py
@@ -1,7 +1,7 @@
 # Checking for a public holiday at Rackham's (HIP 58832)
 # Returns True or False based on whether or not Rackham's is in public holiday
 # Rackham Capital Investments is the faction controlling Rackham's Peak
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from json import JSONDecodeError
 
 import httpx
@@ -49,8 +49,8 @@ async def get_state_from_edsm() -> tuple[bool, datetime]:
 async def api_ph_check() -> tuple[bool, datetime]:
     logger.info("Checking PH state from external APIs.")
     updated_at = datetime.now(tz=UTC)
+    logger.debug("Attempting to get the state from EDSM.")
     try:
-        logger.debug("Attempting to get the state from EDSM.")
         state, updated_at = await get_state_from_edsm()
         if state:
             logger.info("PH state detected from EDSM.")
@@ -59,11 +59,7 @@ async def api_ph_check() -> tuple[bool, datetime]:
         logger.error("Problem while getting the state from EDSM.")
         if isinstance(e, httpx.HTTPError) or isinstance(e, JSONDecodeError):
             logger.error(f"HTTP Exception for {e.request.url} - {e}")
-        elif isinstance(e, StaleDataException):
-            logger.error(e)
-        else:
-            raise
-
+        raise
     # Return false if there are no public holiday hits
     logger.info("No PH state detected from external API.")
     return False, updated_at


### PR DESCRIPTION
```
2026-03-03 13:24:19.099 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: GET https://www.edsm.net/api-system-v1/factions?systemName=HIP+58832 "HTTP/1.1 200 OK"
2026-03-03 13:24:19.101 | ERROR    | ptn.boozebot.modules.PHcheck:api_ph_check:59 - Problem while getting the state from EDSM.
2026-03-03 13:24:19.101 | ERROR    | ptn.boozebot.modules.PHcheck:api_ph_check:63 - Stale data detected from EDSM. Last Updated: 2026-02-28 12:55:23+00:00
2026-03-03 13:24:19.101 | INFO     | ptn.boozebot.modules.PHcheck:api_ph_check:68 - No PH state detected from external API.
2026-03-03 13:24:19.101 | INFO     | ptn.boozebot.botcommands.PublicHoliday:public_holiday_loop:162 - Rackham's holiday API check returned: False, last updated: 2026-03-03 13:24:18.844916+00:00
2026-03-03 13:24:19.101 | INFO     | ptn.boozebot.botcommands.PublicHoliday:_set_public_holiday_state:79 - Setting public holiday state to: False, force update: False
```